### PR TITLE
fixed error:output file for fuzzed data

### DIFF
--- a/AFL_replace_mutate/afl-fuzz.c
+++ b/AFL_replace_mutate/afl-fuzz.c
@@ -5850,7 +5850,7 @@ EXP_ST void setup_dirs_fds(void) {
 
 EXP_ST void setup_stdio_file(void) {
 
-  u8* fn = alloc_printf("%s/.cur_input.java", out_dir);
+  u8* fn = alloc_printf("%s/.cur_input", out_dir);
 
   unlink(fn); /* Ignore errors */
 


### PR DESCRIPTION
[At line 5853 in afl-fuzz.c](https://github.com/s3team/Polyglot/blob/69453605b66adf4fc875cf5dbaf7360472382c50/AFL_replace_mutate/afl-fuzz.c#L5853), the current fuzzed data is stored in the file named `cur_input.java` This is feasible only if the application being targeted is either a Java compiler or an application capable of accepting Java file types. This causes a crash while Polyglot fuzzer is run to fuzz, say, `gcc` because `gcc` only accepts c type files.

In line with the advanced techniques of AFL, it is referred to as `cur_input` when saving the file intended for the target application. Modifications have been made to this process.